### PR TITLE
Integrate ted_ungm_search tools into search configuration UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import json
 import time
 import logging
 from datetime import datetime, timedelta
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Tuple
 
 try:
     import requests
@@ -34,6 +34,12 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, scoped_session, load_only
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from logging.handlers import RotatingFileHandler
+
+from ted_ungm_search.ted_client import (
+    DEFAULT_FIELDS as TED_DEFAULT_FIELDS,
+    build_query as build_ted_query,
+)
+from ted_ungm_search.ungm_helpers import build_ungm_deeplink
 
 # 데이터베이스 모델 설정
 Base = declarative_base()
@@ -96,6 +102,108 @@ def setup_logging():
 
 setup_logging()
 
+DEFAULT_TED_QUERY = "FT=(solar OR wind OR renewable OR energy)"
+DEFAULT_TED_FIELDS = list(TED_DEFAULT_FIELDS)
+for _extra_field in [
+    "description",
+    "deadline-date",
+    "buyer-country",
+    "notice-type",
+]:
+    if _extra_field not in DEFAULT_TED_FIELDS:
+        DEFAULT_TED_FIELDS.append(_extra_field)
+
+
+def _split_tokens(raw: str) -> List[str]:
+    if not raw:
+        return []
+    tokens: List[str] = []
+    for part in raw.replace("\n", ",").split(","):
+        token = part.strip()
+        if token:
+            tokens.append(token)
+    return tokens
+
+
+def _ensure_list(value: Any) -> List[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return _split_tokens(value)
+    return []
+
+
+def _parse_ted_config(config_text: Optional[str]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    settings: Dict[str, Any] = {
+        "query": DEFAULT_TED_QUERY,
+        "fields": list(DEFAULT_TED_FIELDS),
+        "limit": 100,
+        "sort_field": "publication-date",
+        "sort_order": "DESC",
+        "mode": "page",
+        "page": 1,
+    }
+    builder: Dict[str, Any] = {}
+
+    if not config_text:
+        return settings, builder
+
+    try:
+        data = json.loads(config_text)
+    except (TypeError, ValueError):
+        settings["query"] = config_text
+        return settings, builder
+
+    if not isinstance(data, dict):
+        settings["query"] = config_text
+        return settings, builder
+
+    query_value = data.get("query")
+    if isinstance(query_value, str) and query_value.strip():
+        settings["query"] = query_value
+
+    fields_value = data.get("fields")
+    if isinstance(fields_value, list):
+        cleaned_fields = [str(field).strip() for field in fields_value if str(field).strip()]
+        if cleaned_fields:
+            settings["fields"] = cleaned_fields
+
+    limit_value = data.get("limit")
+    try:
+        if limit_value is not None:
+            limit_int = int(limit_value)
+            if limit_int > 0:
+                settings["limit"] = limit_int
+    except (TypeError, ValueError):
+        pass
+
+    sort_field = data.get("sort_field") or data.get("sortBy")
+    if isinstance(sort_field, str) and sort_field.strip():
+        settings["sort_field"] = sort_field.strip()
+
+    sort_order = data.get("sort_order") or data.get("order")
+    if isinstance(sort_order, str) and sort_order.strip():
+        settings["sort_order"] = sort_order.strip()
+
+    mode_value = data.get("mode")
+    if isinstance(mode_value, str) and mode_value.strip():
+        settings["mode"] = mode_value.strip()
+
+    page_value = data.get("page")
+    try:
+        if page_value is not None:
+            page_int = int(page_value)
+            if page_int > 0:
+                settings["page"] = page_int
+    except (TypeError, ValueError):
+        pass
+
+    builder_candidate = data.get("builder")
+    if isinstance(builder_candidate, dict):
+        builder = builder_candidate
+
+    return settings, builder
+
 class TenderCrawler:
     def __init__(self):
         if requests is None:
@@ -114,7 +222,13 @@ class TenderCrawler:
     def get_search_config(self, site: str) -> str:
         """검색 설정 조회"""
         config = session.query(SearchConfig).filter_by(site=site).first()
-        return config.query if config else ""
+        return config.query or "" if config else ""
+
+    def get_ted_settings(self) -> Dict[str, Any]:
+        """Parse TED 검색 설정을 구조화된 dict로 반환"""
+        config = session.query(SearchConfig).filter_by(site="TED").first()
+        settings, _ = _parse_ted_config(config.query if config else None)
+        return settings
     
     def save_to_db(self, tender_data: Dict[str, Any]) -> bool:
         """입찰 정보를 DB에 저장 (UPSERT)"""
@@ -249,23 +363,52 @@ class TenderCrawler:
         
         url = "https://api.ted.europa.eu/v3/notices/search"
         
-        # 검색식 구성
-        search_query = self.get_search_config('TED')
-        if not search_query:
-            search_query = 'FT=(solar OR wind OR renewable OR energy)'
-        
+        ted_settings = self.get_ted_settings()
+        search_query = ted_settings.get("query") or DEFAULT_TED_QUERY
+        fields = ted_settings.get("fields") or list(DEFAULT_TED_FIELDS)
+        if not isinstance(fields, list):
+            fields = list(DEFAULT_TED_FIELDS)
+        limit = ted_settings.get("limit", 100)
+        sort_field = ted_settings.get("sort_field", "publication-date")
+        sort_order = ted_settings.get("sort_order", "DESC")
+        page_number = ted_settings.get("page", 1)
+
+        try:
+            limit_value = int(limit)
+            if limit_value <= 0:
+                limit_value = 100
+        except (TypeError, ValueError):
+            limit_value = 100
+
+        try:
+            page_value = int(page_number)
+            if page_value <= 0:
+                page_value = 1
+        except (TypeError, ValueError):
+            page_value = 1
+
+        sort_order_value = str(sort_order).upper() if sort_order else "DESC"
+
         payload = {
             "query": search_query,
-            "fields": [
-                "publication-number", "title", "description", 
-                "publication-date", "deadline-date", "buyer-country", 
-                "buyer-name", "notice-type"
-            ],
-            "limit": 100,
+            "fields": fields,
+            "limit": limit_value,
             "scope": "ACTIVE",
-            "sortBy": "publication-date",
-            "order": "DESC"
+            "sortBy": sort_field,
+            "order": sort_order_value,
+            "page": page_value,
         }
+
+        app.logger.info(
+            "Prepared TED search payload",
+            extra={
+                "fields": ",".join(fields),
+                "limit": limit_value,
+                "sort": sort_field,
+                "order": sort_order_value,
+                "page": page_value,
+            },
+        )
         
         try:
             response = self.session.post(url, json=payload, timeout=30)
@@ -426,9 +569,71 @@ def index():
 def search_config():
     """검색식 관리"""
     if request.method == 'POST':
-        ungm_keywords = request.form.get('ungm_keywords', '')
-        ted_query = request.form.get('ted_query', '')
-        
+        ungm_keywords = request.form.get('ungm_keywords', '').strip()
+
+        today = datetime.utcnow().date()
+        default_ted_to = today.isoformat()
+        default_ted_from = (today - timedelta(days=30)).isoformat()
+
+        ted_date_from = request.form.get('ted_date_from', '').strip() or default_ted_from
+        ted_date_to = request.form.get('ted_date_to', '').strip() or default_ted_to
+        ted_countries = [token.upper() for token in _split_tokens(request.form.get('ted_countries', ''))]
+        ted_cpv = _split_tokens(request.form.get('ted_cpv', ''))
+        ted_keywords_input = request.form.get('ted_keywords', '')
+        ted_keywords = _split_tokens(ted_keywords_input)
+        ted_form_types = [token.upper() for token in _split_tokens(request.form.get('ted_form_types', ''))]
+        ted_fields_raw = request.form.get('ted_fields', '')
+        ted_fields = _split_tokens(ted_fields_raw)
+        if not ted_fields:
+            ted_fields = list(DEFAULT_TED_FIELDS)
+
+        try:
+            ted_limit = int(request.form.get('ted_limit', 100))
+            if ted_limit <= 0:
+                ted_limit = 100
+        except (TypeError, ValueError):
+            ted_limit = 100
+
+        try:
+            ted_page = int(request.form.get('ted_page', 1))
+            if ted_page <= 0:
+                ted_page = 1
+        except (TypeError, ValueError):
+            ted_page = 1
+
+        ted_sort_field = request.form.get('ted_sort_field', 'publication-date').strip() or 'publication-date'
+        ted_sort_order = request.form.get('ted_sort_order', 'DESC').strip().upper() or 'DESC'
+        ted_mode = request.form.get('ted_mode', 'page').strip() or 'page'
+
+        ted_query = build_ted_query(
+            date_from=ted_date_from,
+            date_to=ted_date_to,
+            countries=ted_countries,
+            cpv_prefixes=ted_cpv,
+            keywords=ted_keywords,
+            form_types=ted_form_types,
+        )
+
+        ted_payload = {
+            "version": 1,
+            "query": ted_query,
+            "builder": {
+                "date_from": ted_date_from,
+                "date_to": ted_date_to,
+                "countries": ted_countries,
+                "cpv_prefixes": ted_cpv,
+                "keywords": ted_keywords,
+                "form_types": ted_form_types,
+            },
+            "fields": ted_fields,
+            "limit": ted_limit,
+            "sort_field": ted_sort_field,
+            "sort_order": ted_sort_order,
+            "mode": ted_mode,
+            "page": ted_page,
+        }
+        ted_payload_text = json.dumps(ted_payload, ensure_ascii=False)
+
         # UNGM 설정 저장
         ungm_config = session.query(SearchConfig).filter_by(site='UNGM').first()
         if ungm_config:
@@ -437,27 +642,69 @@ def search_config():
         else:
             ungm_config = SearchConfig(site='UNGM', query=ungm_keywords, last_updated=datetime.utcnow())
             session.add(ungm_config)
-        
+
         # TED 설정 저장
         ted_config = session.query(SearchConfig).filter_by(site='TED').first()
         if ted_config:
-            ted_config.query = ted_query
+            ted_config.query = ted_payload_text
             ted_config.last_updated = datetime.utcnow()
         else:
-            ted_config = SearchConfig(site='TED', query=ted_query, last_updated=datetime.utcnow())
+            ted_config = SearchConfig(site='TED', query=ted_payload_text, last_updated=datetime.utcnow())
             session.add(ted_config)
-        
+
         session.commit()
         app.logger.info("Search configurations updated")
         return redirect(url_for('search_config'))
-    
+
     # GET 요청 - 현재 설정 로드
     ungm_config = session.query(SearchConfig).filter_by(site='UNGM').first()
     ted_config = session.query(SearchConfig).filter_by(site='TED').first()
-    
-    return render_template('search_config.html', 
-                         ungm_keywords=ungm_config.query if ungm_config else '',
-                         ted_query=ted_config.query if ted_config else '')
+
+    ungm_keywords_value = ungm_config.query if ungm_config else ''
+    ungm_keyword_list = _split_tokens(ungm_keywords_value)
+    ungm_preview_link = build_ungm_deeplink(keywords=ungm_keyword_list)
+
+    ted_settings, ted_builder = _parse_ted_config(ted_config.query if ted_config else None)
+
+    today = datetime.utcnow().date()
+    default_ted_to = today.isoformat()
+    default_ted_from = (today - timedelta(days=30)).isoformat()
+
+    builder_data = {
+        "date_from": str(ted_builder.get("date_from") or default_ted_from),
+        "date_to": str(ted_builder.get("date_to") or default_ted_to),
+        "countries": [value.upper() for value in _ensure_list(ted_builder.get("countries"))],
+        "cpv_prefixes": _ensure_list(ted_builder.get("cpv_prefixes")),
+        "keywords": _ensure_list(ted_builder.get("keywords")),
+        "form_types": [value.upper() for value in _ensure_list(ted_builder.get("form_types"))],
+    }
+
+    ted_fields_text = "\n".join(ted_settings.get("fields", DEFAULT_TED_FIELDS))
+    ted_limit_value = ted_settings.get("limit", 100)
+    ted_sort_field = ted_settings.get("sort_field", "publication-date")
+    ted_sort_order = (ted_settings.get("sort_order") or "DESC").upper()
+    ted_mode = ted_settings.get("mode", "page")
+    ted_page_value = ted_settings.get("page", 1)
+
+    return render_template(
+        'search_config.html',
+        ungm_keywords=ungm_keywords_value,
+        ungm_preview_link=ungm_preview_link,
+        ted_query_preview=ted_settings.get("query", DEFAULT_TED_QUERY),
+        ted_date_from=builder_data["date_from"],
+        ted_date_to=builder_data["date_to"],
+        ted_countries=", ".join(builder_data["countries"]),
+        ted_cpv=", ".join(builder_data["cpv_prefixes"]),
+        ted_keywords=", ".join(builder_data["keywords"]),
+        ted_form_types=", ".join(builder_data["form_types"]),
+        ted_fields_text=ted_fields_text,
+        ted_limit=ted_limit_value,
+        ted_sort_field=ted_sort_field,
+        ted_sort_order=ted_sort_order,
+        ted_mode=ted_mode,
+        ted_page=str(ted_page_value),
+        ted_default_fields=DEFAULT_TED_FIELDS,
+    )
 
 @app.route('/tenders')
 def tender_list():

--- a/templates/search_config.html
+++ b/templates/search_config.html
@@ -6,50 +6,161 @@
 {% block title %}검색 설정 - MCP 입찰 정보 수집 서버{% endblock %}
 
 {% block content %}
+<style>
+    .form-section {
+        margin-bottom: 2rem;
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid #eee;
+    }
+    .form-section:last-of-type {
+        border-bottom: none;
+        padding-bottom: 0;
+    }
+    .form-section h3 {
+        margin-top: 0;
+    }
+    .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+    }
+    .form-grid .form-group {
+        margin-bottom: 0;
+    }
+    textarea[readonly] {
+        background-color: #f4f6f8;
+        color: #4a5568;
+    }
+    .preview-field {
+        background: #f8f9fa;
+        border: 1px dashed #d0d7de;
+        padding: 0.75rem;
+        border-radius: 4px;
+        font-size: 0.9rem;
+        word-break: break-all;
+    }
+</style>
+
 <div class="card">
     <h2>검색 설정 관리</h2>
-    <p>UNGM과 TED 사이트에서 입찰 공고를 검색할 때 사용할 키워드와 검색식을 설정합니다.</p>
-    
+    <p>ted_ungm_search 도구의 검색 빌더를 활용하여 UNGM 키워드와 TED 고급 검색 조건을 설정할 수 있습니다.</p>
+
     <form method="POST">
-        <div class="form-group">
-            <label for="ungm_keywords">UNGM 검색 키워드</label>
-            <input type="text" 
-                   id="ungm_keywords" 
-                   name="ungm_keywords" 
-                   value="{{ ungm_keywords }}"
-                   placeholder="예: solar,wind,renewable,energy">
-            <small>쉼표(,)로 구분하여 여러 키워드를 입력하세요. 제목에 해당 키워드가 포함된 공고만 수집됩니다.</small>
+        <div class="form-section">
+            <h3>UNGM 검색 조건</h3>
+            <div class="form-group">
+                <label for="ungm_keywords">UNGM 검색 키워드</label>
+                <input type="text"
+                       id="ungm_keywords"
+                       name="ungm_keywords"
+                       value="{{ ungm_keywords }}"
+                       placeholder="예: solar,wind,renewable,energy">
+                <small>쉼표 또는 줄바꿈으로 여러 키워드를 입력하세요. 제목에 해당 키워드가 포함된 공고만 수집됩니다.</small>
+            </div>
+            <div class="form-group">
+                <label>UNGM 미리보기 링크</label>
+                <div class="preview-field">
+                    <a href="{{ ungm_preview_link }}" target="_blank" rel="noopener">{{ ungm_preview_link }}</a>
+                </div>
+                <small>ted_ungm_search의 <code>build_ungm_deeplink</code> 유틸리티를 이용해 즉시 검색해볼 수 있는 URL입니다.</small>
+            </div>
         </div>
-        
-        <div class="form-group">
-            <label for="ted_query">TED 전문 검색식</label>
-            <input type="text" 
-                   id="ted_query" 
-                   name="ted_query" 
-                   value="{{ ted_query }}"
-                   placeholder="예: FT=(solar OR wind OR renewable OR energy)">
-            <small>TED Expert Query 문법을 사용합니다. FT=(키워드1 OR 키워드2) 형식으로 입력하세요.</small>
+
+        <div class="form-section">
+            <h3>TED 검색 빌더</h3>
+            <p style="margin-top: -0.5rem; color: #555;">날짜 범위와 국가, CPV, 키워드 등을 입력하면 ted_ungm_search의 <code>build_query</code> 로직을 통해 검색식이 자동 생성됩니다.</p>
+
+            <div class="form-grid">
+                <div class="form-group">
+                    <label for="ted_date_from">발행일 (시작)</label>
+                    <input type="date" id="ted_date_from" name="ted_date_from" value="{{ ted_date_from }}">
+                </div>
+                <div class="form-group">
+                    <label for="ted_date_to">발행일 (종료)</label>
+                    <input type="date" id="ted_date_to" name="ted_date_to" value="{{ ted_date_to }}">
+                </div>
+                <div class="form-group">
+                    <label for="ted_limit">페이지 크기 (limit)</label>
+                    <input type="number" id="ted_limit" name="ted_limit" value="{{ ted_limit }}" min="1" max="250">
+                </div>
+                <div class="form-group">
+                    <label for="ted_page">시작 페이지</label>
+                    <input type="number" id="ted_page" name="ted_page" value="{{ ted_page }}" min="1">
+                </div>
+            </div>
+
+            <div class="form-grid" style="margin-top: 1rem;">
+                <div class="form-group">
+                    <label for="ted_countries">국가 (ISO 2자리)</label>
+                    <input type="text" id="ted_countries" name="ted_countries" value="{{ ted_countries }}" placeholder="예: DE,FR,IT">
+                    <small>쉼표 또는 줄바꿈으로 여러 국가를 입력하세요. place-of-performance와 buyer-country 필터가 결합됩니다.</small>
+                </div>
+                <div class="form-group">
+                    <label for="ted_cpv">CPV 코드 접두어</label>
+                    <input type="text" id="ted_cpv" name="ted_cpv" value="{{ ted_cpv }}" placeholder="예: 33*,0931*">
+                    <small>와일드카드(*)를 포함할 수 있습니다.</small>
+                </div>
+            </div>
+
+            <div class="form-grid" style="margin-top: 1rem;">
+                <div class="form-group">
+                    <label for="ted_keywords">제목 키워드</label>
+                    <input type="text" id="ted_keywords" name="ted_keywords" value="{{ ted_keywords }}" placeholder="예: solar,wind">
+                    <small>문구 검색은 공백을 포함한 단어를 그대로 입력하세요. 쉼표 또는 줄바꿈으로 여러 키워드를 구분합니다.</small>
+                </div>
+                <div class="form-group">
+                    <label for="ted_form_types">eForms Form Type</label>
+                    <input type="text" id="ted_form_types" name="ted_form_types" value="{{ ted_form_types }}" placeholder="예: F15,F03">
+                    <small>필요한 경우에만 입력하세요.</small>
+                </div>
+            </div>
+
+            <div class="form-group" style="margin-top: 1rem;">
+                <label for="ted_fields">반환 필드 목록</label>
+                <textarea id="ted_fields" name="ted_fields" rows="3" placeholder="필드를 쉼표 또는 줄바꿈으로 구분합니다.">{{ ted_fields_text }}</textarea>
+                <small>값을 비워두면 권장 기본 필드가 사용됩니다: {{ ted_default_fields | join(', ') }}.</small>
+            </div>
+
+            <div class="form-grid" style="margin-top: 1rem;">
+                <div class="form-group">
+                    <label for="ted_sort_field">정렬 필드</label>
+                    <input type="text" id="ted_sort_field" name="ted_sort_field" value="{{ ted_sort_field }}">
+                </div>
+                <div class="form-group">
+                    <label for="ted_sort_order">정렬 방향</label>
+                    <select id="ted_sort_order" name="ted_sort_order">
+                        <option value="DESC" {% if ted_sort_order == 'DESC' %}selected{% endif %}>DESC</option>
+                        <option value="ASC" {% if ted_sort_order == 'ASC' %}selected{% endif %}>ASC</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="ted_mode">조회 모드</label>
+                    <select id="ted_mode" name="ted_mode">
+                        <option value="page" {% if ted_mode == 'page' %}selected{% endif %}>페이지 모드</option>
+                        <option value="iteration" {% if ted_mode == 'iteration' %}selected{% endif %}>Iteration 모드</option>
+                    </select>
+                    <small>현재 서버 크롤러는 페이지 모드를 사용하지만 설정값은 그대로 저장됩니다.</small>
+                </div>
+            </div>
+
+            <div class="form-group" style="margin-top: 1.5rem;">
+                <label>생성된 TED 검색식</label>
+                <textarea readonly rows="3">{{ ted_query_preview }}</textarea>
+                <small>위 입력값을 기반으로 <code>ted_ungm_search.ted_client.build_query</code>가 생성한 검색식입니다.</small>
+            </div>
         </div>
-        
+
         <button type="submit" class="btn">설정 저장</button>
     </form>
-    
+
     <div style="margin-top: 2rem; padding-top: 2rem; border-top: 1px solid #eee;">
-        <h3>검색 문법 도움말</h3>
+        <h3>도움말</h3>
         <div style="background: #f8f9fa; padding: 1rem; border-radius: 4px;">
-            <h4>UNGM 키워드</h4>
             <ul>
-                <li>쉼표로 구분된 키워드들은 OR 조건으로 검색됩니다</li>
-                <li>예: "solar,wind,renewable" → 제목에 solar, wind, renewable 중 하나라도 포함된 공고</li>
-                <li>빈 값으로 두면 모든 공고를 수집합니다</li>
-            </ul>
-            
-            <h4>TED 전문 검색식</h4>
-            <ul>
-                <li>FT=(키워드1 OR 키워드2): 전체 텍스트에서 키워드 검색</li>
-                <li>AND, OR, NOT 연산자 사용 가능 (대문자)</li>
-                <li>괄호로 그룹핑 가능</li>
-                <li>예: FT=(solar OR wind) AND NOT nuclear</li>
+                <li>발행일 범위는 반드시 지정해야 하며, 기본값은 최근 30일입니다.</li>
+                <li>국가, CPV, 키워드, Form Type은 선택 사항이며 입력하지 않으면 해당 필터가 적용되지 않습니다.</li>
+                <li>필드 목록을 비우면 ted_ungm_search 기본 필드({{ ted_default_fields | join(', ') }})가 사용됩니다.</li>
+                <li>설정 저장 후 수동 크롤링을 실행하면 새로운 검색식과 필드 구성이 즉시 적용됩니다.</li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- integrate ted_ungm_search helpers to normalise TED default fields, parse stored configs and log crawler payloads
- expand the search configuration endpoint to build TED queries from structured form data and persist JSON alongside UNGM deep links
- refresh the search configuration template with advanced builder inputs, a generated query preview and usage guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c8e374b7e88328bd11ad961245f904