### PR TITLE
Make TED search requests via POST and stabilise UNGM token retrieval

### DIFF
--- a/ted_ungm_search/ted_client.py
+++ b/ted_ungm_search/ted_client.py
@@ -153,9 +153,9 @@ def _normalise_fields(fields: Optional[Sequence[str]]) -> List[str]:
     wait=wait_exponential(multiplier=1, min=1, max=10),
     retry=retry_if_exception_type((requests.RequestException, TedTransientError)),
 )
-def _perform_request(params: Dict[str, Union[str, int]]) -> dict:
-    logger.debug("Performing TED request", extra={"params": params})
-    response = _session.get(API_URL, params=params, timeout=REQUEST_TIMEOUT)
+def _perform_request(payload: Dict[str, Union[str, int]]) -> dict:
+    logger.debug("Performing TED request", extra={"payload": payload})
+    response = _session.post(API_URL, json=payload, timeout=REQUEST_TIMEOUT)
     if response.status_code in {429} or 500 <= response.status_code < 600:
         raise TedTransientError(
             f"Retryable HTTP status {response.status_code}",


### PR DESCRIPTION
## Summary
- add a helper that extracts the UNGM verification token from HTML, cookies, and raw text before posting the search request
- send the TED search payload as JSON via POST (including optional mode) to satisfy the API
- update the shared TED client helper to mirror the POST-based workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c8eddc483c8328b76f39e7a4e24520