### PR TITLE
Include SAM.gov in manual crawl summary

### DIFF
--- a/app.py
+++ b/app.py
@@ -1058,7 +1058,7 @@ class TenderCrawler:
 # 크롤러 인스턴스
 crawler = TenderCrawler()
 
-def crawl_all():
+def crawl_all() -> Dict[str, Any]:
     """전체 크롤링 작업"""
     app.logger.info("Starting scheduled crawling job...")
     start_time = datetime.now()
@@ -1079,6 +1079,13 @@ def crawl_all():
         sam_count,
         ted_count,
     )
+
+    return {
+        "ungm": ungm_count,
+        "sam": sam_count,
+        "ted": ted_count,
+        "duration": duration,
+    }
 
 # 스케줄러 설정
 scheduler = BackgroundScheduler() if BackgroundScheduler else None
@@ -1153,8 +1160,14 @@ def get_tenders():
 def manual_crawl():
     """수동 크롤링 트리거"""
     try:
-        crawl_all()
-        return jsonify({"status": "success", "message": "Crawling completed"})
+        results = crawl_all()
+        return jsonify(
+            {
+                "status": "success",
+                "message": "Crawling completed",
+                "results": results,
+            }
+        )
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)}), 500
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="card">
     <h1>MCP 입찰 정보 수집 서버</h1>
-    <p>UNGM과 TED 입찰 공고를 자동으로 수집하고 관리하는 시스템입니다.</p>
+    <p>UNGM, SAM.gov 및 TED 입찰 공고를 자동으로 수집하고 관리하는 시스템입니다.</p>
     
     <div class="stats">
         <div class="stat-card">
@@ -85,7 +85,15 @@ async function manualCrawl(event) {
         const result = await response.json();
         
         if (result.status === 'success') {
-            statusDiv.textContent = '크롤링 완료! 페이지를 새로고침하여 업데이트된 데이터를 확인하세요.';
+            const summary = result.results || {};
+            const ungmCount = summary.ungm ?? '-';
+            const samCount = summary.sam ?? '-';
+            const tedCount = summary.ted ?? '-';
+            const durationInfo = Number.isFinite(summary.duration)
+                ? ` (소요 시간: ${summary.duration.toFixed(1)}초)`
+                : '';
+
+            statusDiv.textContent = `크롤링 완료! UNGM: ${ungmCount}건, SAM.gov: ${samCount}건, TED: ${tedCount}건 수집되었습니다.${durationInfo} 페이지를 새로고침하여 업데이트된 데이터를 확인하세요.`;
             statusDiv.className = 'alert alert-success';
             setTimeout(() => {
                 location.reload();


### PR DESCRIPTION
## Summary
- return crawl job metrics from `crawl_all` so manual triggers include SAM.gov counts alongside other sources
- surface the SAM.gov totals in the dashboard manual crawl confirmation message and update the description text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c9291c14a48328bc253fa23b1f46ab