### PR TITLE
Improve UNGM and TED crawling resilience

### DIFF
--- a/ted_ungm_search/ted_client.py
+++ b/ted_ungm_search/ted_client.py
@@ -137,14 +137,14 @@ def build_query(
 
 
 def _normalise_fields(fields: Optional[Sequence[str]]) -> List[str]:
-    if not fields:
+    if fields is None:
         return list(DEFAULT_FIELDS)
     result: List[str] = []
     for field in fields:
         field_name = field.strip()
         if field_name:
             result.append(field_name)
-    return result or list(DEFAULT_FIELDS)
+    return result
 
 
 @retry(
@@ -215,13 +215,19 @@ def search_once(
     """Execute a single TED search request."""
 
     selected_fields = _normalise_fields(fields)
+    include_fields_param = fields is not None
     params: Dict[str, Any] = {
         "q": q,
-        "fields": selected_fields,
         "limit": limit,
         "sort": sort_field,
         "order": sort_order,
     }
+
+    if include_fields_param:
+        if selected_fields:
+            params["fields"] = selected_fields
+    else:
+        params["fields"] = selected_fields
 
     if iteration_token:
         logger.info(


### PR DESCRIPTION
## Summary
- refresh UNGM verification tokens, retry the search on FileNotFound responses, and handle JSON notice payloads with flexible date parsing
- normalise UNGM helper values, mask SAM.gov API keys in logs, and improve crawler fallbacks when responses change format
- normalise TED field selections and retry the search without explicit projections when the API rejects the provided list

## Testing
- pytest ted_ungm_search/tests/test_query_building.py

------
https://chatgpt.com/codex/tasks/task_b_68c937114e688328b03462edd508c27a